### PR TITLE
短縮URLクリック集計のDBスキーマと実装の整合性を修正

### DIFF
--- a/app/api/endpoints/templates.py
+++ b/app/api/endpoints/templates.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends
 from core.security_cognito import verify_admin as verify_admin_dep
-from services.templates import (get_templates, create_template, update_template, delete_template)
+from services.templates import (get_templates, create_template, update_template, delete_template, activate_template)
 
 router = APIRouter()
 
@@ -19,6 +19,13 @@ async def edit_template(
     _: dict = Depends(verify_admin_dep),
 ):
     return await update_template(template_id, template_data)
+
+@router.patch("/templates/{template_id}/activate")
+async def activate_template_api(
+    template_id: str,
+    _: dict = Depends(verify_admin_dep),
+):
+    return await activate_template(template_id)
 
 @router.delete("/templates/{template_id}")
 async def remove_template(

--- a/app/clients/dynamodb.py
+++ b/app/clients/dynamodb.py
@@ -2,11 +2,14 @@ import boto3
 from boto3.dynamodb.conditions import Key
 from core.config import settings
 from datetime import datetime
+from typing import Dict, Any, List
 
 # テーブル名
 ADMIN_TABLE_NAME = settings.ADMIN_TABLE_NAME
 SETTINGS_TABLE_NAME = "SettingsTable"
 TEMPLATES_TABLE_NAME = "TemplatesTable"
+POSTS_TABLE_NAME = "Posts"
+
 
 # boto3 DynamoDB クライアント
 dynamodb = boto3.resource(
@@ -18,69 +21,62 @@ dynamodb = boto3.resource(
 )
 
 # テーブルの定義
-post_table = dynamodb.Table(ADMIN_TABLE_NAME)
+admins_table = dynamodb.Table(ADMIN_TABLE_NAME)
 settings_table = dynamodb.Table(SETTINGS_TABLE_NAME)
 templates_table = dynamodb.Table(TEMPLATES_TABLE_NAME)
+posts_table = dynamodb.Table(POSTS_TABLE_NAME)
 
 # 投稿データ取得
-def get_post_data():
+def get_post_data() -> List[Dict[str, Any]]:
     try:
-        response = post_table.scan()
-        items = response.get("Items", [])
-        return items
+        resp = posts_table.scan()
+        return resp.get("Items", [])
     except Exception as e:
         print(f"DynamoDBからの投稿データ取得に失敗しました: {e}")
         return []
 
-# 設定取得
-def get_settings_data():
+# 設定（ABテスト比率のみを保持・更新）
+def get_settings_data() -> Dict[str, Any]:
+    # SettingsTable からアプリ共通設定を取得
     try:
-        response = settings_table.get_item(Key={"id": "app_settings"})
-        item = response.get("Item", {})
-
-        # 必須フィールドがない場合はデフォルト値を補完
+        resp = settings_table.get_item(Key={"id": "app_settings"})
+        item = resp.get("Item", {})
         return {
             "id": item.get("id", "app_settings"),
-            "check_interval": item.get("check_interval", 60),
-            "excluded_users": item.get("excluded_users", []),
-            "excluded_keywords": item.get("excluded_keywords", []),
-            "trial_class_link": item.get("trial_class_link", ""),
-            "counseling_link": item.get("counseling_link", ""),
-            "last_checked_at": item.get("last_checked_at", datetime.utcnow().isoformat())
+            "ab_test_ratio": item.get("ab_test_ratio", {}),
         }
     except Exception as e:
         print(f"設定データの取得に失敗しました: {e}")
         return {
             "id": "app_settings",
-            "check_interval": 60,
-            "excluded_users": [],
-            "excluded_keywords": [],
-            "trial_class_link": "",
-            "counseling_link": "",
-            "last_checked_at": datetime.utcnow().isoformat()
+            "ab_test_ratio": {},
         }
 
-# 設定更新
-def update_settings_data(data: dict):
+def update_settings_data(data: Dict[str, Any]) -> bool:
+    # ABテスト比率のみを保存
     try:
-        data["id"] = "app_settings"
-        settings_table.put_item(Item=data)
+        put_item = {
+            "id": "app_settings",
+            "ab_test_ratio": data.get("ab_test_ratio", {}),
+        }
+        settings_table.put_item(Item=put_item)
         return True
     except Exception as e:
         print(f"設定データの更新に失敗しました: {e}")
         return False
 
+
 # テンプレート一覧取得
-def get_templates_data():
+def get_templates_data() -> List[Dict[str, Any]]:
     try:
-        response = templates_table.scan()
-        return response.get("Items", [])
+        resp = templates_table.scan()
+        return resp.get("Items", [])
     except Exception as e:
         print(f"テンプレート一覧の取得に失敗しました: {e}")
         return []
 
 # テンプレート作成
-def create_template_data(template: dict):
+def create_template_data(template: Dict[str, Any]) -> Dict[str, Any]:
     try:
         templates_table.put_item(Item=template)
         return {"message": "テンプレートを登録しました。"}
@@ -89,19 +85,41 @@ def create_template_data(template: dict):
         return {"message": "テンプレートの作成に失敗しました。"}
 
 # テンプレート更新
-def update_template_data(template_id: str, template: dict):
+def update_template_data(template_id: str, template: Dict[str, Any]) -> Dict[str, Any]:
     try:
-        templates_table.put_item(Item={**template, "id": template_id})
+        item = {**template, "id": template_id}
+        templates_table.put_item(Item=item)
         return {"message": "テンプレートを更新しました。"}
     except Exception as e:
         print(f"テンプレートの更新に失敗しました: {e}")
         return {"message": "テンプレートの更新に失敗しました。"}
 
 # テンプレート削除
-def delete_template_data(template_id: str):
+def delete_template_data(template_id: str) -> Dict[str, str]:
     try:
         templates_table.delete_item(Key={"id": template_id})
         return {"message": "テンプレートを削除しました。"}
     except Exception as e:
         print(f"テンプレートの削除に失敗しました: {e}")
         return {"message": "テンプレートの削除に失敗しました。"}
+
+# テンプレート有効化
+def activate_template_data(template_id: str) -> Dict[str, str]:
+    try:
+        # 全件取得して一括更新
+        resp = templates_table.scan()
+        items = resp.get("Items", [])
+
+        with templates_table.batch_writer() as batch:
+            for it in items:
+                tid = it.get("id")
+                if not tid:
+                    continue
+                it["is_active"] = 1 if tid == template_id else 0
+                it["updated_at"] = datetime.utcnow().isoformat()
+                batch.put_item(Item=it)
+
+        return {"message": "テンプレートを有効化しました。"}
+    except Exception as e:
+        print(f"テンプレートの有効化に失敗しました: {e}")
+        return {"message": "テンプレートの有効化に失敗しました。"}    

--- a/app/clients/shortio.py
+++ b/app/clients/shortio.py
@@ -1,4 +1,3 @@
-# app/clients/shortio.py
 import os
 import httpx
 from typing import Optional, Dict, Any

--- a/app/schemas/settings.py
+++ b/app/schemas/settings.py
@@ -5,19 +5,10 @@ from pydantic import BaseModel, Field, ConfigDict
 
 class SettingsResponse(BaseModel):
     settings_id: str = Field(..., alias="id")
-    check_interval: int
-    excluded_users: List[str]
-    excluded_keywords: List[str]
-    trial_class_link: str
-    counseling_link: str
-    last_checked_at: datetime
+    ab_test_ratio: Dict[str, int] 
 
     model_config = ConfigDict(populate_by_name=True)
 
 
 class UpdateSettingsRequest(BaseModel):
-    check_interval: int
-    excluded_users: List[str]
-    excluded_keywords: List[str]
-    trial_class_link: str
-    counseling_link: str
+    ab_test_ratio: Dict[str, int]

--- a/app/schemas/settings.py
+++ b/app/schemas/settings.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Dict, List
 from datetime import datetime
 from pydantic import BaseModel, Field, ConfigDict
 

--- a/app/schemas/templates.py
+++ b/app/schemas/templates.py
@@ -6,24 +6,24 @@ from typing import Optional
 class TemplateItem(BaseModel):
     template_id: str
     template: str
-    is_active: bool
+    is_active: int
     created_at: datetime
     updated_at: datetime
 
 
 class TemplateCreate(BaseModel):
     template: str
-    is_active: bool = True
+    is_active: int = 0
 
 
 class TemplateUpdate(BaseModel):
     template: Optional[str] = None
-    is_active: Optional[bool] = None
+    is_active: Optional[int] = None
 
 
 class TemplateResponse(BaseModel):
     template_id: str
     template: str
-    is_active: bool
+    is_active: int
     created_at: datetime
     updated_at: datetime

--- a/app/services/dashboard.py
+++ b/app/services/dashboard.py
@@ -1,18 +1,134 @@
+from decimal import Decimal
+import os
+import boto3
+from core.config import settings
 from clients.dynamodb import get_post_data
-from services.shortlinks import total_clicks_all_posts
+
+# テーブル名
+ARTICLE_LINK_CLICKS_TABLE = os.getenv("ARTICLE_LINK_CLICKS_TABLE_NAME", "Article_link_clicks")
+STATIC_LINK_CLICKS_TABLE = os.getenv("STATIC_LINK_CLICKS_TABLE_NAME", "Static_link_clicks")
+
+
+def _dynamo():
+    return boto3.resource(
+        "dynamodb",
+        region_name=settings.AWS_REGION,
+        endpoint_url=settings.DYNAMODB_ENDPOINT or None,
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+    )
+
+
+def _to_int(v) -> int:
+    if isinstance(v, Decimal):
+        return int(v)
+    if isinstance(v, (int, float)):
+        return int(v)
+    return 0
+
+
+def _sum_article_metrics() -> dict:
+    # Article_link_clicks から記事リンク用の合計メトリクスを算出
+    tbl = _dynamo().Table(ARTICLE_LINK_CLICKS_TABLE)
+    clicks_article_total = 0
+    tweet_views_total = 0
+    start_key = None
+    while True:
+        if start_key:
+            resp = tbl.scan(
+                ExclusiveStartKey=start_key,
+                ProjectionExpression="clicks_article, tweet_views",
+            )
+        else:
+            resp = tbl.scan(
+                ProjectionExpression="clicks_article, tweet_views",
+            )
+        for item in resp.get("Items", []):
+            clicks_article_total += _to_int(item.get("clicks_article"))
+            tweet_views_total += _to_int(item.get("tweet_views"))
+        start_key = resp.get("LastEvaluatedKey")
+        if not start_key:
+            break
+
+    ctr_article = round((clicks_article_total / tweet_views_total) * 100, 2) if tweet_views_total else 0.0
+    return {
+        "clicks_article_total": clicks_article_total,
+        "tweet_views_total": tweet_views_total,
+        "ctr_article": ctr_article,
+    }
+
+
+def _sum_static_metrics() -> dict:
+    # Static_link_clicks から固定リンク(体験授業/カウンセリング)の合計メトリクスを算出
+    tbl = _dynamo().Table(STATIC_LINK_CLICKS_TABLE)
+    clicks_trial_lesson_total = 0
+    clicks_counseling_total = 0
+    tweet_views_total = 0
+    start_key = None
+    while True:
+        if start_key:
+            resp = tbl.scan(
+                ExclusiveStartKey=start_key,
+                ProjectionExpression="clicks_trial_lesson, clicks_counseling, tweet_views",
+            )
+        else:
+            resp = tbl.scan(
+                ProjectionExpression="clicks_trial_lesson, clicks_counseling, tweet_views",
+            )
+        for item in resp.get("Items", []):
+            clicks_trial_lesson_total += _to_int(item.get("clicks_trial_lesson"))
+            clicks_counseling_total += _to_int(item.get("clicks_counseling"))
+            tweet_views_total += _to_int(item.get("tweet_views"))
+        start_key = resp.get("LastEvaluatedKey")
+        if not start_key:
+            break
+
+    ctr_trial = round((clicks_trial_lesson_total / tweet_views_total) * 100, 2) if tweet_views_total else 0.0
+    ctr_counsel = round((clicks_counseling_total / tweet_views_total) * 100, 2) if tweet_views_total else 0.0
+
+    return {
+        "clicks_trial_lesson_total": clicks_trial_lesson_total,
+        "clicks_counseling_total": clicks_counseling_total,
+        "tweet_views_total": tweet_views_total,
+        "ctr_trial_lesson": ctr_trial,
+        "ctr_counseling": ctr_counsel,
+    }
 
 async def get_dashboard_data():
     # Posts　メタデータ のみを取得
     posts = get_post_data()
+    total_posts = len(posts)
 
-    # クリック総数は ShortlinkMetricsDaily から集計
-    total_clicks = await total_clicks_all_posts()
+    # 記事リンクの集計
+    article = _sum_article_metrics()
+
+    # 固定リンク(体験授業/カウンセリング)の集計
+    static = _sum_static_metrics()
+
+    # 総クリック数 = 記事リンク + 固定リンク
+    total_clicks = (
+        article["clicks_article_total"]
+        + static["clicks_trial_lesson_total"]
+        + static["clicks_counseling_total"]
+    )
 
     # CTR
     summary = {
-        "total_posts": len(posts),
+        "total_posts": total_posts,
         "total_clicks": total_clicks,
-        "ctr": round(total_clicks / len(posts) * 100, 2) if posts else 0.0,
+        # 主要KPIを明示的に分けて返す
+        "article": {
+            "clicks": article["clicks_article_total"],
+            "tweet_views": article["tweet_views_total"],
+            "ctr": article["ctr_article"],  # 記事リンクのCTR
+        },
+        "static_links": {
+            "clicks_trial_lesson": static["clicks_trial_lesson_total"],
+            "clicks_counseling": static["clicks_counseling_total"],
+            "tweet_views": static["tweet_views_total"],
+            "ctr_trial_lesson": static["ctr_trial_lesson"],  # 体験授業のCTR
+            "ctr_counseling": static["ctr_counseling"],      # カウンセリングのCTR
+        },
         "error_count": 0,
     }
 

--- a/app/services/settings.py
+++ b/app/services/settings.py
@@ -1,28 +1,17 @@
 from clients.dynamodb import get_settings_data, update_settings_data
 from schemas.settings import SettingsResponse
 from fastapi import HTTPException
-from datetime import datetime
 
 async def get_settings() -> SettingsResponse:
     try:
         settings_dict = get_settings_data()
-
-        if not settings_dict or not isinstance(settings_dict, dict):
-            return SettingsResponse(
-                id="default-id",
-                check_interval=60,
-                excluded_users=[],
-                excluded_keywords=[],
-                trial_class_link="",
-                counseling_link="",
-                last_checked_at=datetime.utcnow(),
-            )
-
         return SettingsResponse(**settings_dict)
     except Exception as e:
         print(f"設定データの取得に失敗しました: {e}")
         raise HTTPException(status_code=500, detail="設定データの取得に失敗しました")
 
 async def update_settings(new_settings: dict):
-    await update_settings_data(new_settings)
+    ok = update_settings_data(new_settings)
+    if not ok:
+        raise HTTPException(status_code=500, detail="設定データの更新に失敗しました")
     return {"message": "設定を更新しました"}

--- a/app/services/templates.py
+++ b/app/services/templates.py
@@ -1,4 +1,4 @@
-from clients.dynamodb import (get_templates_data, create_template_data, update_template_data, delete_template_data)
+from clients.dynamodb import (get_templates_data, create_template_data, update_template_data, delete_template_data, activate_template_data)
 
 async def get_templates():
     return get_templates_data()
@@ -11,3 +11,6 @@ async def update_template(template_id: str, template: dict):
 
 async def delete_template(template_id: str):
     return delete_template_data(template_id)
+
+async def activate_template(template_id: str):
+    return activate_template_data(template_id)

--- a/app/utils/dynamodb.py
+++ b/app/utils/dynamodb.py
@@ -20,32 +20,60 @@ dynamodb_client = boto3.client(
     aws_secret_access_key="dummy"
 )
 
-def create_table_if_not_exists(table_name, key_schema, attribute_definitions, billing_mode="PAY_PER_REQUEST"):
+def create_table_if_not_exists(**kwargs):
+    table_name = kwargs["TableName"]
     try:
         existing_tables = dynamodb_client.list_tables()["TableNames"]
         if table_name in existing_tables:
             print(f"既にテーブルが存在します: {table_name}")
             return
-
-        dynamodb_client.create_table(
-            TableName=table_name,
-            KeySchema=key_schema,
-            AttributeDefinitions=attribute_definitions,
-            BillingMode=billing_mode
-        )
+        dynamodb_client.create_table(**kwargs)
         print(f"テーブルを作成しました: {table_name}")
-
     except ClientError as e:
         print(f"DynamoDB操作中にエラーが発生しました: {e.response['Error']['Message']}")
         raise
 
 if __name__ == "__main__":
+    # SettingsTable: PK=id
     create_table_if_not_exists(
-        table_name=os.environ.get("SETTINGS_TABLE_NAME", "SettingsTable"),
-        key_schema=[
-            {"AttributeName": "id", "KeyType": "HASH"}
+        TableName=os.environ.get("SETTINGS_TABLE_NAME", "SettingsTable"),
+        KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+    # AdminsTable: PK=id, GSI=cognito_sub-index
+    create_table_if_not_exists(
+        TableName=os.environ.get("ADMIN_TABLE_NAME", "AdminsTable"),
+        KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "id", "AttributeType": "S"},
+            {"AttributeName": "cognito_sub", "AttributeType": "S"},
         ],
-        attribute_definitions=[
-            {"AttributeName": "id", "AttributeType": "S"}
-        ]
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "cognito_sub-index",
+                "KeySchema": [{"AttributeName": "cognito_sub", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+    # TemplatesTable: PK=id, GSI=is_active-index (Number)
+    create_table_if_not_exists(
+        TableName=os.environ.get("TEMPLATES_TABLE_NAME", "TemplatesTable"),
+        KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "id", "AttributeType": "S"},
+            {"AttributeName": "is_active", "AttributeType": "N"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "is_active-index",
+                "KeySchema": [{"AttributeName": "is_active", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+        BillingMode="PAY_PER_REQUEST",
     )


### PR DESCRIPTION
## 目的
- ダッシュボード集計処理が、DynamoDB 上の実際のスキーマ（Article_link_clicks / Static_link_clicks テーブル構成）と乖離していたため、DBスキーマに沿った正しいメトリクス集計を行えるようにする

## 実装の概要/やったこと

- このプルリクで何をしたのか？
- DynamoDB テーブル Article_link_clicks / Static_link_clicks に基づいたメトリクス集計処理を追加
    - 記事リンククリック数・表示回数から CTR を算出
    - 固定リンク（体験授業 / カウンセリング）のクリック数・表示回数から CTR を算出
- get_dashboard_data を修正し、主要KPIを明示的にレスポンスへ返すよう変更
    - summary.article に記事リンクの集計結果を格納
    - summary.static_links に固定リンクの集計結果を格納
- 現行の DynamoDB スキーマに一本化

## 保留/やらないこと

- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

- 何ができるようになるのか？（あれば。無いなら「無し」でOK）

## できなくなること（ユーザ目線）

- 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #5 
- @
