### PR TITLE
FastAPI を AWS Lambda 上で動作させるための対応

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,21 +1,14 @@
-# ベースとなるイメージを指定（軽量な Python 3.11 の slim バージョンを使用）
-FROM python:3.11-slim
+# ベースとなるイメージを指定（AWS Lambda 用の公式 Python 3.11 ランタイムイメージ）
+FROM public.ecr.aws/lambda/python:3.11
 
-# コンテナ内の作業ディレクトリを /app に設定
-WORKDIR /app
-
-# アプリの依存関係ファイルをコンテナにコピー（requirements.txt を現在の作業ディレクトリにコピー）
-COPY app/requirements.txt requirements.txt
+# 依存関係ファイルをコンテナにコピー（requirements.txt を現在の作業ディレクトリにコピー）
+COPY app/requirements.txt .
 
 # 依存関係をインストール（キャッシュを使わずに軽量化）
 RUN pip install --no-cache-dir -r requirements.txt
 
-# アプリケーション本体をすべてコンテナにコピー（app ディレクトリの中身を /app にコピー）
-COPY app/ .
-ENV PYTHONPATH=/app
+# アプリケーション本体をすべてコンテナにコピー（app ディレクトリの中身を LAMBDA_TASK_ROOT に配置）
+COPY app/ ${LAMBDA_TASK_ROOT}
 
-# アプリケーションで使用するポートを開放
-EXPOSE 8000
-
-# コンテナ起動時に実行されるコマンドを指定（uvicorn で main.py 内の app を起動）
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--log-level", "info"]
+# Lambda のエントリポイントを指定（app/lambda_handler.py 内の handler を起動）
+CMD ["app.lambda_handler.handler"]

--- a/app/lambda_handler.py
+++ b/app/lambda_handler.py
@@ -1,0 +1,5 @@
+from mangum import Mangum
+from app.main import app
+
+
+handler = Mangum(app)

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -16,6 +16,9 @@ watchfiles==1.1.0
 boto3==1.39.9
 botocore==1.39.9
 
+# AWS Lambda
+mangum==0.17.0
+
 # 認証（Cognito JWT 検証で使用）
 python-jose==3.5.0
 


### PR DESCRIPTION
## 目的
- FastAPI アプリを AWS Lambda にデプロイできるようにする

## 実装の概要/やったこと
- requirements.txt に `mangum==0.17.0` を追加
- `app/lambda_handler.py` を新規追加し、Mangum を介して FastAPI アプリを Lambda で実行できるように実装
- Dockerfile を AWS Lambda ランタイムイメージに修正
  - requirements.txt をコピーして依存関係をインストール
  - app/ ディレクトリを `${LAMBDA_TASK_ROOT}` に配置
  - CMD を `app.lambda_handler.handler` に指定

- このプルリクで何をしたのか？

## 保留/やらないこと
- ローカル開発用 Dockerfile（Uvicorn 起動）は別途管理

- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## できるようになること
- ECR に push した Lambda 対応イメージを使用して、AWS Lambda 上で FastAPI アプリを動かせるようになる

- 何ができるようになるのか？（あれば。無いなら「無し」でOK）

## できなくなること
- 特になし

- 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認
- ローカルで Lambda ベースのコンテナを起動し、`/docs` にアクセスして FastAPI エンドポイントが動作することを確認

- どのような動作確認を行ったのか？　結果はどうか？

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #14 
- @
