### PR TITLE
Lambda デプロイ用の Dockerfile周りの修正対応

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,14 +1,9 @@
-# ベースとなるイメージを指定（AWS Lambda 用の公式 Python 3.11 ランタイムイメージ）
 FROM public.ecr.aws/lambda/python:3.11
 
-# 依存関係ファイルをコンテナにコピー（requirements.txt を現在の作業ディレクトリにコピー）
 COPY app/requirements.txt .
-
-# 依存関係をインストール（キャッシュを使わずに軽量化）
 RUN pip install --no-cache-dir -r requirements.txt
 
-# アプリケーション本体をすべてコンテナにコピー（app ディレクトリの中身を LAMBDA_TASK_ROOT に配置）
-COPY app/ ${LAMBDA_TASK_ROOT}
+# ★ ここを修正：app/ ディレクトリごと /var/task/app/ に配置
+COPY app/ ${LAMBDA_TASK_ROOT}/app/
 
-# Lambda のエントリポイントを指定（app/lambda_handler.py 内の handler を起動）
 CMD ["app.lambda_handler.handler"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -3,7 +3,11 @@ FROM public.ecr.aws/lambda/python:3.11
 COPY app/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# ★ ここを修正：app/ ディレクトリごと /var/task/app/ に配置
+# app ディレクトリごと配置
 COPY app/ ${LAMBDA_TASK_ROOT}/app/
 
+# ← これがポイント：/var/task/app を import パスに追加
+ENV PYTHONPATH="${LAMBDA_TASK_ROOT}/app:${PYTHONPATH}"
+
+# ハンドラーはそのまま
 CMD ["app.lambda_handler.handler"]

--- a/app/clients/dynamodb.py
+++ b/app/clients/dynamodb.py
@@ -9,10 +9,6 @@ def get_dynamodb_resource():
     if settings.DYNAMODB_ENDPOINT:
         kwargs["endpoint_url"] = settings.DYNAMODB_ENDPOINT
 
-    if settings.AWS_ACCESS_KEY_ID and settings.AWS_SECRET_ACCESS_KEY:
-        kwargs["aws_access_key_id"] = settings.AWS_ACCESS_KEY_ID
-        kwargs["aws_secret_access_key"] = settings.AWS_SECRET_ACCESS_KEY
-
     return boto3.resource("dynamodb", **kwargs)
 
 # テーブルハンドル


### PR DESCRIPTION
## 目的
- AWS Lambda デプロイ用の Dockerfile の構成を整理し、Python モジュールの import パスを明確化。

## 実装の概要/やったこと
- `Dockerfile.prod` を修正し、`app/` ディレクトリを `LAMBDA_TASK_ROOT/app/` に配置するよう変更。
- `PYTHONPATH` に `/var/task/app` を追加し、モジュールを正しく import できるように調整。
- DynamoDB クライアント生成コードから AWS 認証情報の明示的指定部分を削除（Lambda 環境変数や IAM Role を利用する前提に変更）。
- 空の `app/__init__.py` を追加し、`app` を Python パッケージとして扱えるようにした。

## できるようになること（ユーザ目線）
- AWS Lambda 環境でのデプロイ時に、`app` モジュールが正しく import され、エラーなく実行できる。

## できなくなること（ユーザ目線）
- 無し。
