### PR TITLE
デプロイ後の修正

### DIFF
--- a/app/clients/dynamodb.py
+++ b/app/clients/dynamodb.py
@@ -90,7 +90,19 @@ def get_templates_data() -> List[Dict[str, Any]]:
 # テンプレート作成
 def create_template_data(template: Dict[str, Any]) -> Dict[str, Any]:
     try:
-        templates_table.put_item(Item=template)
+        from uuid import uuid4
+        now = datetime.utcnow().isoformat()
+        item = {
+            "PK": "TEMPLATES",
+            "SK": now,
+            "id": template.get("id", str(uuid4())),
+            "template": template.get("template", ""),
+            "is_active": template.get("is_active", 0),
+            "created_at": now,
+            "updated_at": now,
+            # 他に必要な属性があれば追加
+        }
+        templates_table.put_item(Item=item)
         return {"message": "テンプレートを登録しました。"}
     except Exception as e:
         print(f"テンプレートの作成に失敗しました: {e}")
@@ -143,4 +155,4 @@ def activate_template_data(template_id: str) -> Dict[str, str]:
         return {"message": "テンプレートを有効化しました。"}
     except Exception as e:
         print(f"テンプレートの有効化に失敗しました: {e}")
-        return {"message": "テンプレートの有効化に失敗しました。"}    
+        return {"message": "テンプレートの有効化に失敗しました。"}

--- a/app/clients/dynamodb.py
+++ b/app/clients/dynamodb.py
@@ -111,7 +111,18 @@ def create_template_data(template: Dict[str, Any]) -> Dict[str, Any]:
 # テンプレート更新
 def update_template_data(template_id: str, template: Dict[str, Any]) -> Dict[str, Any]:
     try:
-        item = {**template, "id": template_id}
+        # idからPK, SKを特定
+        resp = templates_table.scan(
+            FilterExpression="id = :tid",
+            ExpressionAttributeValues={":tid": template_id}
+        )
+        items = resp.get("Items", [])
+        if not items:
+            return {"message": "テンプレートが見つかりませんでした。"}
+        item = items[0]
+        # 更新内容を反映
+        item.update(template)
+        item["updated_at"] = datetime.utcnow().isoformat()
         templates_table.put_item(Item=item)
         return {"message": "テンプレートを更新しました。"}
     except Exception as e:
@@ -121,7 +132,16 @@ def update_template_data(template_id: str, template: Dict[str, Any]) -> Dict[str
 # テンプレート削除
 def delete_template_data(template_id: str) -> Dict[str, str]:
     try:
-        templates_table.delete_item(Key={"id": template_id})
+        # idからPK, SKを特定
+        resp = templates_table.scan(
+            FilterExpression="id = :tid",
+            ExpressionAttributeValues={":tid": template_id}
+        )
+        items = resp.get("Items", [])
+        if not items:
+            return {"message": "テンプレートが見つかりませんでした。"}
+        item = items[0]
+        templates_table.delete_item(Key={"PK": item["PK"], "SK": item["SK"]})
         return {"message": "テンプレートを削除しました。"}
     except Exception as e:
         print(f"テンプレートの削除に失敗しました: {e}")


### PR DESCRIPTION
## 目的
- DynamoDB に保存するテンプレートデータを、より一貫性のあるスキーマ（PK, SK, id, created_at, updated_at など）で管理できるようにする  
- テンプレート更新/削除の際に id から正しくアイテムを特定できるようにする  

## 実装の概要/やったこと
- **create_template_data**  
  - `uuid4` で id を生成（未指定の場合）  
  - PK= `"TEMPLATES"`, SK=作成時刻を設定  
  - created_at/updated_at を保存するよう修正  
- **update_template_data**  
  - id から対象アイテムを scan で取得  
  - 取得したアイテムに更新内容を反映し、updated_at を更新  
- **delete_template_data**  
  - id から対象アイテムを scan で取得  
  - PK/SK をキーに delete_item するよう修正  

## 保留/やらないこと
- scan のまま実装しているため、効率化（GSI設計やQuery利用）は未対応  
- バリデーションや例外ハンドリングの詳細強化は未対応  
- 上記は別タスクで対応予定  

## できるようになること（ユーザ目線）
- テンプレートの登録・更新・削除が安定して行える  
- 作成日時・更新日時を確認できる  

## できなくなること（ユーザ目線）
- 特になし  

## 動作確認

  - 新規テンプレート登録 → DynamoDB に PK/SK/id/created_at/updated_at が保存されること  
  - 更新処理 → 既存テンプレートの内容が上書きされ、updated_at が更新されること  
  - 削除処理 → 対象のテンプレートが削除されること  

<img width="1082" height="235" alt="Screenshot 2025-08-25 at 21 49 28" src="https://github.com/user-attachments/assets/7509bf8e-b137-4a22-aa40-a5aaba83a11a" />

- 正常にレスポンスメッセージが返却されることを確認  

