### PR TITLE
効果測定ページのクリック数をArticle_link_clicks基準に修正

### DIFF
--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from typing import Dict
 from core.config import settings
 from clients.dynamodb import get_dynamodb_resource, get_post_data
+from .dashboard import _get_article_clicks_map, _sum_static_metrics
 
 
 def _dynamo():
@@ -22,72 +23,35 @@ async def get_metrics() -> dict:
     posts = get_post_data()
     total_posts = len(posts)
 
-    # 記事リンク（Posts）
-    tbl_posts = _dynamo().Table(settings.POSTS_TABLE_NAME)
-    clicks_article_total = 0
-    x_views_total = 0
-    start_key = None
-    while True:
-        if start_key:
-            resp = tbl_posts.scan(
-                ExclusiveStartKey=start_key,
-                ProjectionExpression="clicks_article, x_views",
-            )
-        else:
-            resp = tbl_posts.scan(
-                ProjectionExpression="clicks_article, x_views",
-            )
-        for item in resp.get("Items", []):
-            clicks_article_total += _to_int(item.get("clicks_article"))
-            x_views_total       += _to_int(item.get("x_views"))
-        start_key = resp.get("LastEvaluatedKey")
-        if not start_key:
-            break
-
-    ctr_article = round((clicks_article_total / x_views_total) * 100, 3) if x_views_total else 0.0
+    # 記事リンク（Article_link_clicks）
+    article_clicks_map = _get_article_clicks_map()
+    clicks_article_total = sum(article_clicks_map.values())
 
     # 固定リンク（Static_link_clicks）
-    tbl_static = _dynamo().Table(settings.STATIC_LINK_CLICKS_TABLE_NAME)
-    clicks_trial_total  = 0
-    clicks_counsel_total = 0
-    static_views_total  = 0
-    start_key = None
-    while True:
-        if start_key:
-            resp = tbl_static.scan(
-                ExclusiveStartKey=start_key,
-                ProjectionExpression="clicks_trial_lesson, clicks_counseling, tweet_views",
-            )
-        else:
-            resp = tbl_static.scan(
-                ProjectionExpression="clicks_trial_lesson, clicks_counseling, tweet_views",
-            )
-        for item in resp.get("Items", []):
-            clicks_trial_total   += _to_int(item.get("clicks_trial_lesson"))
-            clicks_counsel_total += _to_int(item.get("clicks_counseling"))
-            static_views_total   += _to_int(item.get("tweet_views"))
-        start_key = resp.get("LastEvaluatedKey")
-        if not start_key:
-            break
+    static = _sum_static_metrics()
 
-    ctr_trial  = round((clicks_trial_total / static_views_total) * 100, 3) if static_views_total else 0.0
-    ctr_counsel = round((clicks_counsel_total / static_views_total) * 100, 3) if static_views_total else 0.0
+    # CTR（記事はビュー数が無いので 0 扱い、必要なら _sum_posts_article_metrics を呼ぶ）
+    ctr_article = 0.0
 
-    total_clicks = clicks_article_total + clicks_trial_total + clicks_counsel_total
+    total_clicks = (
+        clicks_article_total
+        + static["clicks_trial_lesson_total"]
+        + static["clicks_counseling_total"]
+    )
 
     return {
         "total_posts": total_posts,
         "total_clicks": total_clicks,
         "article": {
             "clicks": clicks_article_total,
-            "x_views": x_views_total,
+            "x_views": 0,
             "ctr": ctr_article,
         },
         "static_links": {
-            "clicks_trial_lesson": clicks_trial_total,
-            "clicks_counseling":  clicks_counsel_total,
-            "tweet_views":        static_views_total,
-            "ctr_trial_lesson":   ctr_trial,
-            "ctr_counseling":     ctr_counsel,
+            "clicks_trial_lesson": static["clicks_trial_lesson_total"],
+            "clicks_counseling":  static["clicks_counseling_total"],
+            "tweet_views":        static["tweet_views_total"],
+            "ctr_trial_lesson":   static["ctr_trial_lesson"],
+            "ctr_counseling":     static["ctr_counseling"],
         },
     }


### PR DESCRIPTION
## 目的
- 効果測定ページに表示される総クリック数がダッシュボードと一致していなかったため、データソースを修正して数値を正しく表示させる

## 実装の概要/やったこと
- metrics.py にて Posts テーブルから clicks_article を集計していた処理を削除
- ダッシュボードと同じく Article_link_clicks テーブルを _get_article_clicks_map() から取得するよう変更
- 固定リンク部分の集計処理は _sum_static_metrics() を利用して統一

- このプルリクで何をしたのか？

## 保留/やらないこと

- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

- ダッシュボードと効果測定ページで総クリック数が一致し、正しいデータを確認できるようになる

## できなくなること（ユーザ目線）

- 特になし

## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #
- @
