### PR TITLE
Dockerfileを修正し、依存関係のインストール先を指定。requirements.txtにpytzを追加。

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,13 +1,14 @@
 FROM public.ecr.aws/lambda/python:3.11
 
+# 依存は /var/task (= ${LAMBDA_TASK_ROOT}) にインストールする
 COPY app/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN python -m pip install --no-cache-dir -r requirements.txt -t "${LAMBDA_TASK_ROOT}"
 
-# app ディレクトリごと配置
-COPY app/ ${LAMBDA_TASK_ROOT}/app/
+# アプリ本体
+COPY app/ "${LAMBDA_TASK_ROOT}/app/"
 
-# ← これがポイント：/var/task/app を import パスに追加
+# （任意）/var/task/app を import パスに追加
 ENV PYTHONPATH="${LAMBDA_TASK_ROOT}/app:${PYTHONPATH}"
 
-# ハンドラーはそのまま
+# ハンドラー
 CMD ["app.lambda_handler.handler"]

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -39,3 +39,6 @@ sniffio==1.3.1
 typing-inspection==0.4.1
 typing_extensions==4.14.1
 packaging==25.0
+
+# タイムゾーン（追加）
+pytz==2024.1


### PR DESCRIPTION
## 目的
- Lambda コンテナイメージで発生していた `No module named 'pytz'` エラーを解消するため、`requirements.txt` および Dockerfile を修正する。

## 実装の概要/やったこと
- `requirements.txt` に `pytz==2024.1` を追加
- Dockerfile で依存パッケージを `${LAMBDA_TASK_ROOT}` 配下にインストールするよう修正
  - `pip install -t "${LAMBDA_TASK_ROOT}"` を使用
- アプリディレクトリを `${LAMBDA_TASK_ROOT}/app/` に配置
- `PYTHONPATH` に `${LAMBDA_TASK_ROOT}/app` を追加し import path を明示

## 保留/やらないこと
- 本番不要な依存（`uvicorn`, `uvloop`, `watchfiles` など）の削除 → 今回は見送り、将来的に `requirements-dev.txt` へ分離予定

## できるようになること（ユーザ目線）
- Lambda 上で正常に FastAPI アプリが起動し、`pytz` を利用した処理がエラーなく実行できる

## できなくなること（ユーザ目線）
- 無し

## 動作確認
- Docker ビルド時に `import pytz, fastapi, mangum` を確認しエラーが出ないことを確認
- ローカル実行で `/ping` エンドポイントにアクセスし `{"message": "pong"}` が返ることを確認
- ECR に push したイメージを Lambda にデプロイし、実際の呼び出しでエラーが発生しないことを確認

## その他
- 本番イメージ軽量化のため、開発専用依存を分離する改善は別 PR で対応予定
- close #
- @
